### PR TITLE
add hashing objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var isStream = require('is-stream');
 
 var hasha = module.exports = function (buf, opts) {
 	opts = opts || {};
+	
+	buf = JSON.stringify(buf) || buf;
 
 	var inputEncoding = typeof buf === 'string' ? 'utf8' : undefined;
 	var outputEncoding = opts.encoding || 'hex';

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ test('hasha()', function (t) {
 	var fixture = new Buffer('unicorn');
 	t.assert(hasha(fixture).length === 128);
 	t.assert(hasha('unicorn').length === 128);
+	t.assert(hasha({foo: 'bar'}).length === 128);
 	t.assert(Buffer.isBuffer(hasha(fixture, {encoding: 'buffer'})));
 	t.assert(hasha(fixture, {algorithm: 'md5'}).length === 32);
 	t.end();


### PR DESCRIPTION
Hi!
How about adding the ability to hash objects? From my point of view, it would be nice. 
```javascript
var hasha = require('hasha');
console.log(hasha({"foo":"bar"}));//0db68ad4e41d3b26ba3fc48a5da7c9f616b813e77cb4e951187e1f2a37c2bad94041089f89f6012ee7b44e21f863c5d9553e3b665edae8640bb2274b555266eb
```