### PR TITLE
Fix stream error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ hasha.fromStream = function (stream, opts) {
 
 	return new Promise(function (resolve, reject) {
 		stream
-			.pipe(hasha.stream(opts).on('error', reject))
+			.on('error', reject)
+			.pipe(hasha.stream(opts))
 			.on('error', reject)
 			.on('finish', function () {
 				resolve(this.read());

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "proxyquire": "^1.7.2",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -30,6 +30,13 @@ test('hasha.fromFile()', function (t) {
 	});
 });
 
+test('hasha.fromFile(non-existent)', function (t) {
+	t.plan(1);
+	return hasha.fromFile('non-existent-file.txt').catch(function (err) {
+		t.is(err.code, 'ENOENT');
+	});
+});
+
 test('hasha.fromFileSync()', function (t) {
 	t.is(hasha.fromFileSync('test.js').length, 128);
 	t.end();

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@ var fs = require('fs');
 var test = require('ava');
 var isStream = require('is-stream');
 var hasha = require('./');
+var proxyquire = require('proxyquire');
+var Writeable = require('stream').Writable;
 
 test('hasha()', function (t) {
 	var fixture = new Buffer('unicorn');
@@ -21,6 +23,27 @@ test('hasha.stream()', function (t) {
 test('hasha.fromStream()', function (t) {
 	return hasha.fromStream(fs.createReadStream('test.js')).then(function (hash) {
 		t.is(hash.length, 128);
+	});
+});
+
+test('crypto error', function (t) {
+	t.plan(1);
+
+	var proxied = proxyquire('./', {
+		crypto: {
+			createHash: function () {
+				var stream = new Writeable();
+				stream._write = function () {
+					this.emit('error', new Error('some crypto error'));
+				};
+				stream.setEncoding = function () {};
+				return stream;
+			}
+		}
+	});
+
+	return proxied.fromStream(fs.createReadStream('test.js')).catch(function (err) {
+		t.is(err.message, 'some crypto error');
 	});
 });
 


### PR DESCRIPTION
Split into two commits.

The first adds a fix (and test) for an error handling bug. You were listening for `error` on the destination stream twice, not once on the input stream, and once on the destination (crypto) stream.

The second commit adds a test validating behavior in the event the crypto stream emits an error. It's pretty verbose (using proxyquire to mock crypto). I couldn't think of a more succinct way to pull that off.