### PR TITLE
Allow an array of strings and or buffers as input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,20 +4,29 @@ var crypto = require('crypto');
 var isStream = require('is-stream');
 var Promise = require('pinkie-promise');
 
-var hasha = module.exports = function (buf, opts) {
+var hasha = module.exports = function (input, opts) {
 	opts = opts || {};
 
-	var inputEncoding = typeof buf === 'string' ? 'utf8' : undefined;
 	var outputEncoding = opts.encoding || 'hex';
 
 	if (outputEncoding === 'buffer') {
 		outputEncoding = undefined;
 	}
 
-	return crypto
-		.createHash(opts.algorithm || 'sha512')
-		.update(buf, inputEncoding)
-		.digest(outputEncoding);
+	var hash = crypto.createHash(opts.algorithm || 'sha512');
+
+	var update = function (buf) {
+		var inputEncoding = typeof buf === 'string' ? 'utf8' : undefined;
+		hash.update(buf, inputEncoding);
+	};
+
+	if (Array.isArray(input)) {
+		input.forEach(update);
+	} else {
+		update(input);
+	}
+
+	return hash.digest(outputEncoding);
 };
 
 hasha.stream = function (opts) {

--- a/readme.md
+++ b/readme.md
@@ -61,11 +61,13 @@ Returns a hash.
 
 #### input
 
-Type: `buffer`, `string`
+Type: `buffer`, `string`, `array` of `string`|`buffer`
 
 Buffer you want to hash.
 
 While strings are supported you should prefer buffers as they're faster to hash. Though if you already have a string you should not convert it to a buffer.
+
+Pass an array instead of concatenating strings and/or buffers. The output is the same, but arrays do not incur the overhead of concatenation.
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -10,6 +10,8 @@ test('hasha()', t => {
 	const fixture = new Buffer('unicorn');
 	t.is(fn(fixture).length, 128);
 	t.is(fn('unicorn').length, 128);
+	t.is(fn(['foo', 'bar']).length, 128);
+	t.is(fn(['foo', new Buffer('bar')]), fn('foobar'));
 	t.true(Buffer.isBuffer(fn(fixture, {encoding: 'buffer'})));
 	t.is(fn(fixture, {algorithm: 'md5'}).length, 32);
 });


### PR DESCRIPTION
This is identical to concatenating the values together, but does not incur that overhead.