### PR TITLE
Allow mixed input arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import {Hash} from 'crypto';
 import {Readable as ReadableStream} from 'stream';
 
 export type ToStringEncoding = 'hex' | 'base64' | 'latin1';
-export type HashaInput = string | string[] | Buffer | Buffer[];
+export type HashaInput = Buffer | string | Array<Buffer | string>;
 export type HashaEncoding = ToStringEncoding | 'buffer';
 
 // TODO: Remove this clutter after https://github.com/Microsoft/TypeScript/issues/29729 is resolved

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,6 +6,10 @@ expectType<string>(hasha('unicorn', {algorithm: 'md5'}));
 expectType<string>(hasha('unicorn', {encoding: 'latin1'}));
 expectType<Buffer>(hasha('unicorn', {encoding: 'buffer'}));
 
+expectType<string>(hasha(['unicorn']));
+expectType<string>(hasha([Buffer.from('unicorn', 'utf8')]));
+expectType<string>(hasha(['unicorn', Buffer.from('unicorn', 'utf8')]));
+
 process.stdin.pipe(hasha.stream()).pipe(process.stdout);
 
 expectType<Promise<string | null>>(hasha.fromStream(process.stdin));

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Returns a hash.
 
 #### input
 
-Type: `Buffer | string | Buffer[] | string[]`
+Type: `Buffer | string | Array<Buffer | string>`
 
 Buffer you want to hash.
 


### PR DESCRIPTION
The code allows the input to be an array of string and Buffer values, but the type definition precludes it.

This updates the type definition, the readme and for good measure the TypeScript "tests".