### PR TITLE
Fix `.fromFile()` Node.js 14 compatibility

### DIFF
--- a/thread.js
+++ b/thread.js
@@ -12,7 +12,7 @@ const handlers = {
 			.pipe(hasher)
 			.on('error', reject)
 			.on('finish', () => {
-				const {buffer} = hasher.read();
+				const {buffer} = new Uint8Array(hasher.read());
 				resolve({value: buffer, transferList: [buffer]});
 			});
 	}),
@@ -27,8 +27,8 @@ const handlers = {
 			hasher.update(input);
 		}
 
-		const hash = hasher.digest().buffer;
-		return {value: hash, transferList: [hash]};
+		const {buffer} = new Uint8Array(hasher.digest());
+		return {value: buffer, transferList: [buffer]};
 	}
 };
 


### PR DESCRIPTION
Add cloning buffer before returning from thread, fixes #29